### PR TITLE
Set CSV-file permissions to 0666

### DIFF
--- a/src/php/Generator.php
+++ b/src/php/Generator.php
@@ -108,6 +108,7 @@ class Generator {
 
 		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_read_file_put_contents
 		file_put_contents( $temp_filename, $file_contents );
+		chmod( $temp_filename, 0666 );
 
 		$end = microtime( true );
 


### PR DESCRIPTION
If MySQL and PHP are in different Docker containers and have different uid/gid  the MySQL one doesn't see a target CSV-file, because the file is created with 0600 permissions (in my case)