### PR TITLE
Nested comments

### DIFF
--- a/src/php/Generator/Comment.php
+++ b/src/php/Generator/Comment.php
@@ -135,9 +135,9 @@ class Comment extends Item {
 			$parent_id = $parent->comment_ID;
 
 			// Post from parent comment.
-			$post = new \stdClass();
-			$post->ID = $parent->comment_post_ID;
-			$post->post_date = $parent->comment_date;
+			$post                = new \stdClass();
+			$post->ID            = $parent->comment_post_ID;
+			$post->post_date     = $parent->comment_date;
 			$post->post_date_gmt = $parent->comment_date_gmt;
 		} else {
 			// This is top-level comment.
@@ -260,7 +260,7 @@ class Comment extends Item {
 	 *
 	 * @return stdClass[]
 	 */
-	private function prepare_comments()	{
+	private function prepare_comments() {
 		global $wpdb;
 
 		// Only use parent comments from the current chunk posts.
@@ -272,13 +272,12 @@ class Comment extends Item {
 			$posts
 		);
 
-		$post_id_placeholders = implode( ', ', array_fill( 0, count( $post_ids ), '%d' ) );
-
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 		return $wpdb->get_results(
 			$wpdb->prepare(
 				"SELECT comment_ID, comment_post_ID, comment_date, comment_date_gmt
 					FROM $wpdb->comments
-					WHERE comment_post_ID IN ( $post_id_placeholders )",
+					WHERE comment_post_ID IN ( " . implode( ', ', array_fill( 0, count( $post_ids ), '%d' ) ) . ' )',
 				$post_ids
 			)
 		);

--- a/src/php/Generator/Comment.php
+++ b/src/php/Generator/Comment.php
@@ -263,6 +263,7 @@ class Comment extends Item {
 	private function prepare_comments()	{
 		global $wpdb;
 
+		// Only use parent comments from the current chunk posts.
 		$posts    = $this->post_id_randomizer->get( self::RANDOM_POSTS_COUNT );
 		$post_ids = array_map(
 			function( $item ) {


### PR DESCRIPTION
This PR adds nested comments.

Nested comments could only be created if adding in steps. Every next step will consider existing comments as parent. If all comments are added within single step, there will be mo child comments.

### Possible Drawbacks

With the current approach, generator will add 50% child comments with each new chunk. It is causing some problems:

Comments are not distributing equally to posts. With every new chunk, posts which already have comments will have higher chance to receive new comment (as child comment) then posts which doesn't have much comments yet. And this chance is growing with every new chunk.

It may cause the situation when some posts have thousands of comment and others don't have comments at all:

Test setup:
- Posts already in database 10000
- Generate 500000 comments (expecting to get about 500 comments per post)
- Chunk size 50000 (means 10 runs)

The result:
- Most commented post: 9800 comments
- Less commented post: 0 comments

### Alternative design

To fix the distribution of comments, we may need make the `NESTED_PERCENTAGE` a variable thing, to reduce the percentage of child comments with every new step. Need to be discussed and more tests...